### PR TITLE
Add running job stats response

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ services:
 rvm:
   - 2.3.4
   - 2.4.1
+  - 2.5
+  - 2.6
 gemfile:
   - gemfiles/sidekiq_5.gemfile
   - gemfiles/sidekiq_4.gemfile

--- a/README.md
+++ b/README.md
@@ -79,6 +79,16 @@ This is an example of the output you'll get:
       "concurrency":5,
       "busy":5
     }
+  ],
+  "jobs": [
+    {
+      "process": "foo:1234",
+      "thread": "1001",
+      "jid": "1234abc",
+      "queue": "default",
+      "job": "WebWorker",
+      "run_at": "2015-04-10T15:07:52+00:00"
+    }
   ]
 }
 ```

--- a/lib/sidekiq/monitor/stats.rb
+++ b/lib/sidekiq/monitor/stats.rb
@@ -28,6 +28,24 @@ module Sidekiq
           }
         end
       end
+
+      def job_metrics
+        jobs = []
+
+        Sidekiq::Workers.new.each do |process, thread, msg|
+          job = Sidekiq::Job.new(msg['payload'])
+          jobs << {
+            process: process,
+            thread: thread,
+            jid: job.jid,
+            queue: msg['queue'],
+            job: job.display_class,
+            run_at: Time.at(msg['run_at'])
+          }
+        end
+
+        jobs
+      end
     end
   end
 end

--- a/lib/sidekiq/monitor/stats.rb
+++ b/lib/sidekiq/monitor/stats.rb
@@ -30,11 +30,10 @@ module Sidekiq
       end
 
       def job_metrics
-        jobs = []
-
-        Sidekiq::Workers.new.each do |process, thread, msg|
+        Sidekiq::Workers.new.map do |process, thread, msg|
           job = Sidekiq::Job.new(msg['payload'])
-          jobs << {
+
+          {
             process: process,
             thread: thread,
             jid: job.jid,
@@ -43,8 +42,6 @@ module Sidekiq
             run_at: Time.at(msg['run_at'])
           }
         end
-
-        jobs
       end
     end
   end

--- a/lib/sidekiq/monitor/stats.rb
+++ b/lib/sidekiq/monitor/stats.rb
@@ -35,11 +35,11 @@ module Sidekiq
 
           {
             process: process,
-            thread: thread,
-            jid: job.jid,
-            queue: msg['queue'],
-            job: job.display_class,
-            run_at: Time.at(msg['run_at'])
+            thread:  thread,
+            jid:     job.jid,
+            queue:   msg['queue'],
+            job:     job.display_class,
+            run_at:  Time.at(msg['run_at'])
           }
         end
       end

--- a/lib/sidekiq/monitor/web.rb
+++ b/lib/sidekiq/monitor/web.rb
@@ -9,7 +9,8 @@ module Sidekiq
 
           data = {
             queues:    monitor_stats.queue_metrics,
-            processes: monitor_stats.process_metrics
+            processes: monitor_stats.process_metrics,
+            jobs:      monitor_stats.job_metrics
           }
 
           if Sidekiq::VERSION >= "5.0.0"

--- a/test/sidekiq-monitor-stats_test.rb
+++ b/test/sidekiq-monitor-stats_test.rb
@@ -8,6 +8,7 @@ class Sidekiq::Monitor::StatsTest < Minitest::Test
   def test_returns_empty_data
     assert_equal({}, stats.queue_metrics)
     assert_equal([], stats.process_metrics)
+    assert_equal([], stats.job_metrics)
   end
 
   def test_with_some_data

--- a/test/sidekiq-monitor-web_test.rb
+++ b/test/sidekiq-monitor-web_test.rb
@@ -16,6 +16,7 @@ class Sidekiq::Monitor::WebTest < Minitest::Test
     body = Sidekiq.load_json(last_response.body)
     assert_equal({}, body['queues'])
     assert_equal([], body['processes'])
+    assert_equal([], body['jobs'])
   end
 
   def test_monitor_stats_with_some_data

--- a/test/sidekiq-monitor-web_test.rb
+++ b/test/sidekiq-monitor-web_test.rb
@@ -28,6 +28,13 @@ class Sidekiq::Monitor::WebTest < Minitest::Test
         'queues'     => ['default', 'high'],
         'concurrency'=> 25,
         'busy'       => 4
+      ],
+      job_metrics: [
+        'process' => 'foo:1234',
+        'thread'  => '1001',
+        'jid'     => '1234abc',
+        'queue'   => 'default',
+        'job'     => 'WebWorker',
       ]
     )
     get '/monitor-stats'
@@ -45,6 +52,14 @@ class Sidekiq::Monitor::WebTest < Minitest::Test
     assert_equal ['default','high'], process['queues']
     assert_equal 25,                 process['concurrency']
     assert_equal 4,                  process['busy']
+
+    assert_equal 1, body['jobs'].size
+    job = body['jobs'].first
+    assert_equal 'foo:1234',  job['process']
+    assert_equal '1001',      job['thread']
+    assert_equal '1234abc',   job['jid']
+    assert_equal 'default',   job['queue']
+    assert_equal 'WebWorker', job['job']
   end
 
   private


### PR DESCRIPTION
## Summary

Add running job stats response.

### Why

I want to monitor job running time.

## Additional Information

- Add newer ruby version test on Travis CI.
- If you don't like this feature, I will create another plugin. I'm OK!