### PR TITLE
Sidekiq 6 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,14 @@ language: ruby
 cache: bundler
 services:
   - redis-server
+before_install:
+  - yes | gem update --system --force
+  - gem install bundler -v 1.17.2
 rvm:
-  - 2.3.4
-  - 2.4.1
   - 2.5
   - 2.6
+  - 2.7
 gemfile:
+  - gemfiles/sidekiq_6.gemfile
   - gemfiles/sidekiq_5.gemfile
   - gemfiles/sidekiq_4.gemfile

--- a/Appraisals
+++ b/Appraisals
@@ -1,7 +1,11 @@
+appraise "sidekiq-6" do
+  gem "sidekiq", "~> 6.0"
+end
+
 appraise "sidekiq-5" do
-  gem "sidekiq", "< 6.0"
+  gem "sidekiq", "~> 5.0"
 end
 
 appraise "sidekiq-4" do
-  gem "sidekiq", "< 5.0"
+  gem "sidekiq", "~> 4.0"
 end

--- a/gemfiles/sidekiq_4.gemfile
+++ b/gemfiles/sidekiq_4.gemfile
@@ -3,6 +3,6 @@
 source "https://rubygems.org"
 
 gem "byebug"
-gem "sidekiq", "< 5.0"
+gem "sidekiq", "~> 4.0"
 
 gemspec path: "../"

--- a/gemfiles/sidekiq_4.gemfile.lock
+++ b/gemfiles/sidekiq_4.gemfile.lock
@@ -48,7 +48,7 @@ DEPENDENCIES
   mocha
   rack-test
   rake (~> 10.0)
-  sidekiq (< 5.0)
+  sidekiq (~> 4.0)
   sidekiq-monitor-stats!
   sinatra
 

--- a/gemfiles/sidekiq_5.gemfile.lock
+++ b/gemfiles/sidekiq_5.gemfile.lock
@@ -48,7 +48,7 @@ DEPENDENCIES
   mocha
   rack-test
   rake (~> 10.0)
-  sidekiq (< 6.0)
+  sidekiq (~> 5.0)
   sidekiq-monitor-stats!
   sinatra
 

--- a/gemfiles/sidekiq_6.gemfile
+++ b/gemfiles/sidekiq_6.gemfile
@@ -3,6 +3,6 @@
 source "https://rubygems.org"
 
 gem "byebug"
-gem "sidekiq", "~> 5.0"
+gem "sidekiq", "~> 6.0"
 
 gemspec path: "../"

--- a/gemfiles/sidekiq_6.gemfile.lock
+++ b/gemfiles/sidekiq_6.gemfile.lock
@@ -1,0 +1,57 @@
+PATH
+  remote: ..
+  specs:
+    sidekiq-monitor-stats (0.0.3)
+      sidekiq
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    appraisal (2.3.0)
+      bundler
+      rake
+      thor (>= 0.14.0)
+    byebug (11.1.3)
+    connection_pool (2.2.3)
+    minitest (5.14.1)
+    mocha (1.11.2)
+    mustermann (1.1.1)
+      ruby2_keywords (~> 0.0.1)
+    rack (2.2.2)
+    rack-protection (2.0.8.1)
+      rack
+    rack-test (1.1.0)
+      rack (>= 1.0, < 3)
+    rake (10.5.0)
+    redis (4.1.4)
+    ruby2_keywords (0.0.2)
+    sidekiq (6.0.7)
+      connection_pool (>= 2.2.2)
+      rack (~> 2.0)
+      rack-protection (>= 2.0.0)
+      redis (>= 4.1.0)
+    sinatra (2.0.8.1)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.8.1)
+      tilt (~> 2.0)
+    thor (1.0.1)
+    tilt (2.0.10)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  appraisal
+  bundler (~> 1.7)
+  byebug
+  minitest (>= 5.0.0)
+  mocha
+  rack-test
+  rake (~> 10.0)
+  sidekiq (~> 6.0)
+  sidekiq-monitor-stats!
+  sinatra
+
+BUNDLED WITH
+   1.17.2

--- a/lib/sidekiq/monitor/stats.rb
+++ b/lib/sidekiq/monitor/stats.rb
@@ -1,9 +1,12 @@
 require 'sidekiq/api'
 require 'sidekiq/web'
+if Sidekiq::VERSION >= "6.0.0"
+  require 'sidekiq/monitor'
+end
 require 'sidekiq/monitor/web'
 
 module Sidekiq
-  module Monitor
+  class Monitor
     class Stats
       def queue_metrics
         Sidekiq::Queue.all.each_with_object({}) do |queue, hash|

--- a/lib/sidekiq/monitor/web.rb
+++ b/lib/sidekiq/monitor/web.rb
@@ -1,7 +1,7 @@
 require 'sidekiq/monitor/stats'
 
 module Sidekiq
-  module Monitor
+  class Monitor
     module Web
       def self.registered(app)
         app.get "/monitor-stats" do


### PR DESCRIPTION
Fixes https://github.com/harvesthq/sidekiq-monitor-stats/issues/6

Seems like Sidekiq 6 introduced a `Sidekiq::Monitor` class, so us namespacing things inside a `Sidekiq::Monitor` module conflicts.

Since Harvest isn't going to use this gem in the near future, I went for the simplest solution I could thing, and changed them to `class Monitor`, requiring `sidekiq/monitor` if we're in Sidekiq 6 to make sure it loads first.